### PR TITLE
Make `TextTokenIterator` work with `[]byte` as input

### DIFF
--- a/tokenizer/text_token_iterator.go
+++ b/tokenizer/text_token_iterator.go
@@ -7,8 +7,9 @@ import (
 	"unicode"
 )
 
-//
-
+// TextToken represents a piece of text extracted from a larger input.
+// It holds information regarding its beginning and ending offsets in
+// the input text.  A text token may span the entire input.
 type TextToken struct {
 	text  string
 	begin int
@@ -27,8 +28,8 @@ func (tt *TextToken) End() int {
 	return tt.end
 }
 
-//
-
+// TextTokenIterator helps in retrieving consecutive text tokens from
+// an input text.
 type TextTokenIterator struct {
 	in  string
 	ct  *TextToken
@@ -53,8 +54,8 @@ func (ti *TextTokenIterator) Item() Token {
 	return ti.ct
 }
 
-//
-
+// MoveNext is an iterator method towards implementation of the
+// `TokenIterator` interface.
 func (ti *TextTokenIterator) MoveNext() error {
 	inStr := false
 	inNum := false

--- a/tokenizer/text_token_iterator.go
+++ b/tokenizer/text_token_iterator.go
@@ -3,7 +3,6 @@ package tokenizer
 import (
 	"bytes"
 	"io"
-	"strings"
 	"unicode"
 )
 
@@ -31,19 +30,19 @@ func (tt *TextToken) End() int {
 // TextTokenIterator helps in retrieving consecutive text tokens from
 // an input text.
 type TextTokenIterator struct {
-	in  string
+	in  []byte
 	ct  *TextToken
 	idx int
 	buf bytes.Buffer
 }
 
-func NewTextTokenIterator(input string) *TextTokenIterator {
+func NewTextTokenIterator(input []byte) *TextTokenIterator {
 	ti := &TextTokenIterator{}
 	ti.in = input
 	return ti
 }
 
-func NewTextTokenIteratorWithRunningIndex(input string, idx int) *TextTokenIterator {
+func NewTextTokenIteratorWithRunningIndex(input []byte, idx int) *TextTokenIterator {
 	ti := &TextTokenIterator{}
 	ti.in = input
 	ti.idx = idx
@@ -59,7 +58,7 @@ func (ti *TextTokenIterator) Item() Token {
 func (ti *TextTokenIterator) MoveNext() error {
 	inStr := false
 	inNum := false
-	rd := strings.NewReader(ti.in[ti.idx:])
+	rd := bytes.NewReader(ti.in[ti.idx:])
 	begin, end := ti.idx, ti.idx
 
 loop:
@@ -75,7 +74,7 @@ loop:
 				}
 
 				if ti.buf.Len() > 0 {
-					ti.ct = &TextToken{ti.in[begin:end], begin, end - 1}
+					ti.ct = &TextToken{string(ti.in[begin:end]), begin, end - 1}
 					ti.buf.Reset()
 					ti.idx = end
 					return err
@@ -91,7 +90,7 @@ loop:
 		case unicode.IsPunct(r), unicode.IsSymbol(r):
 			{
 				if ti.buf.Len() > 0 {
-					ti.ct = &TextToken{ti.in[begin:end], begin, end - 1}
+					ti.ct = &TextToken{string(ti.in[begin:end]), begin, end - 1}
 					ti.buf.Reset()
 					ti.idx = end
 					return err
@@ -107,7 +106,7 @@ loop:
 		case unicode.IsNumber(r):
 			{
 				if inStr {
-					ti.ct = &TextToken{ti.in[begin:end], begin, end - 1}
+					ti.ct = &TextToken{string(ti.in[begin:end]), begin, end - 1}
 					ti.buf.Reset()
 					ti.idx = end
 					return err
@@ -121,7 +120,7 @@ loop:
 		case unicode.IsLetter(r):
 			{
 				if inNum {
-					ti.ct = &TextToken{ti.in[begin:end], begin, end - 1}
+					ti.ct = &TextToken{string(ti.in[begin:end]), begin, end - 1}
 					ti.buf.Reset()
 					ti.idx = end
 					return err
@@ -140,7 +139,7 @@ loop:
 	}
 
 	if ti.buf.Len() > 0 {
-		ti.ct = &TextToken{ti.in[begin:end], begin, end - 1}
+		ti.ct = &TextToken{string(ti.in[begin:end]), begin, end - 1}
 		ti.buf.Reset()
 		ti.idx = end
 		return nil

--- a/tokenizer/token_iterator.go
+++ b/tokenizer/token_iterator.go
@@ -1,15 +1,17 @@
 package tokenizer
 
-//
-
+// Token represents a piece of text extracted from a larger input.  It
+// holds information regarding its beginning and ending offsets in the
+// input text.  A token may span the entire input.
 type Token interface {
 	Text() string
 	Begin() int
 	End() int
 }
 
-//
-
+// TokenIterator helps in retrieving consecutive tokens.  Side effects
+// of the iteration happen in `MoveNext`.  Therefore, `Item` can be
+// called multiple times, should there be such a need.
 type TokenIterator interface {
 	MoveNext() error
 	Item() Token


### PR DESCRIPTION
- Add documentation to methods
