### PR TITLE
Refactor for easier API and consistent naming

### DIFF
--- a/tokenizer/document.go
+++ b/tokenizer/document.go
@@ -103,6 +103,22 @@ func (d *Document) Tokenize() {
 	}
 }
 
+// AssembleSentences builds sentences the text tokens obtained as a
+// result of tokenization of the sections in the document.
+func (d *Document) AssembleSentences() {
+	var si *SentenceIterator
+	var err error
+
+	for sec, toks := range d.tokens {
+		si = NewSentenceIterator(toks)
+		var sents []*Sentence
+		for err = si.MoveNext(); err == nil; err = si.MoveNext() {
+			sents = append(sents, si.Item())
+		}
+		d.sents[sec] = sents
+	}
+}
+
 // Annotate records the given annotation against the applicable
 // sequence of tokens in the appropriate section of the document.  It
 // creates and stores a `Word` corresponding to the text in the
@@ -159,8 +175,8 @@ func (d *Document) wordForAnnotation(a *Annotation, toks []*TextToken) (*Word, e
 	return w, nil
 }
 
-// TokensInSection answers any recognised tokens in the given section.
-func (d *Document) TokensInSection(sec string) []*TextToken {
+// SectionTokens answers recognised tokens in the given section.
+func (d *Document) SectionTokens(sec string) []*TextToken {
 	if v, ok := d.tokens[sec]; ok {
 		return v
 	}
@@ -178,8 +194,27 @@ func (d *Document) SectionTokenCount(sec string) (int, error) {
 	return -1, fmt.Errorf("Unknown section : %s", sec)
 }
 
-// WordsInSection answers any recognised words in the given section.
-func (d *Document) WordsInSection(sec string) []*Word {
+// SectionSentences answers assembled sentences in the given section.
+func (d *Document) SectionSentences(sec string) []*Sentence {
+	if v, ok := d.sents[sec]; ok {
+		return v
+	}
+
+	return nil
+}
+
+// SectionSentenceCount answers the number of assembled sentences in
+// the given section.
+func (d *Document) SectionSentenceCount(sec string) (int, error) {
+	if v, ok := d.sents[sec]; ok {
+		return len(v), nil
+	}
+
+	return -1, fmt.Errorf("Unknown section : %s", sec)
+}
+
+// SectionWords answers recognised words in the given section.
+func (d *Document) SectionWords(sec string) []*Word {
 	if v, ok := d.words[sec]; ok {
 		return v
 	}
@@ -197,9 +232,9 @@ func (d *Document) SectionWordCount(sec string) (int, error) {
 	return -1, fmt.Errorf("Unknown section : %s", sec)
 }
 
-// AnnotationsForSection answers the registered annotations for the
-// given section.
-func (d *Document) AnnotationsForSection(sec string) []*Annotation {
+// SectionAnnotations answers registered annotations for the given
+// section.
+func (d *Document) SectionAnnotations(sec string) []*Annotation {
 	if v, ok := d.annos[sec]; ok {
 		return v
 	}

--- a/tokenizer/sentence_test.go
+++ b/tokenizer/sentence_test.go
@@ -19,11 +19,11 @@ import (
 
 type Offsets struct {
 	Begin int
-	End int
+	End   int
 }
 
 type DocOffsets struct {
-	Id string
+	Id    string
 	TOffs []Offsets
 	AOffs []Offsets
 }
@@ -87,22 +87,19 @@ func tokenize(bf2 *bufio.Reader, bf3 *bufio.Writer) {
 		doc.SetInput("T", fs[1])
 		doc.SetInput("A", fs[2])
 		doc.Tokenize()
+		doc.AssembleSentences()
 
-		var sents []*Sentence
 		var soffs []string
-		si := NewSentenceIterator(doc.TokensInSection("T"))
-		for err = si.MoveNext(); err == nil; err = si.MoveNext() {
-			sents = append(sents, si.Item())
-			soffs = append(soffs, fmt.Sprintf("%d:%d", si.Item().Begin(), si.Item().End()))
+		sents := doc.SectionSentences("T")
+		for _, sent := range sents {
+			soffs = append(soffs, fmt.Sprintf("%d:%d", sent.Begin(), sent.End()))
 		}
 		bf3.WriteString(fmt.Sprintf("%s\t%s\t", fs[0], strings.Join(soffs, ",")))
 
-		sents = sents[:0]
 		soffs = soffs[:0]
-		si = NewSentenceIterator(doc.TokensInSection("A"))
-		for err = si.MoveNext(); err == nil; err = si.MoveNext() {
-			sents = append(sents, si.Item())
-			soffs = append(soffs, fmt.Sprintf("%d:%d", si.Item().Begin(), si.Item().End()))
+		sents = doc.SectionSentences("A")
+		for _, sent := range sents {
+			soffs = append(soffs, fmt.Sprintf("%d:%d", sent.Begin(), sent.End()))
 		}
 		bf3.WriteString(fmt.Sprintf("%s\n", strings.Join(soffs, ",")))
 	}

--- a/tokenizer/text_token.go
+++ b/tokenizer/text_token.go
@@ -80,7 +80,7 @@ func (ti *TextTokenIterator) MoveNext() error {
 	begin, end := ti.idx, ti.idx
 
 	for r, n, err := rd.ReadRune(); err == nil; r, n, err = rd.ReadRune() {
-		tt := TypeOfRune(r)
+		tt := RuneType(r)
 		switch tt {
 		case TokTerm, TokMayBeTerm, TokPause,
 			TokParenOpen, TokParenClose,
@@ -95,14 +95,14 @@ func (ti *TextTokenIterator) MoveNext() error {
 					ti.ct = &TextToken{string(ti.in[begin:end]), begin, end - 1, TokMayBeWord}
 					ti.buf.Reset()
 					ti.idx = end
-					return err
+					return nil
 				}
 
 				begin = end
 				end = begin + n
 				ti.ct = &TextToken{string(r), begin, end - 1, tt}
 				ti.idx = end
-				return err
+				return nil
 			}
 
 		case TokNumber:
@@ -111,7 +111,7 @@ func (ti *TextTokenIterator) MoveNext() error {
 					ti.ct = &TextToken{string(ti.in[begin:end]), begin, end - 1, TokMayBeWord}
 					ti.buf.Reset()
 					ti.idx = end
-					return err
+					return nil
 				} else {
 					inNum = true
 					end += n
@@ -125,7 +125,7 @@ func (ti *TextTokenIterator) MoveNext() error {
 					ti.ct = &TextToken{string(ti.in[begin:end]), begin, end - 1, TokMayBeWord}
 					ti.buf.Reset()
 					ti.idx = end
-					return err
+					return nil
 				} else {
 					end += n
 				}

--- a/tokenizer/text_token_test.go
+++ b/tokenizer/text_token_test.go
@@ -11,27 +11,41 @@ import (
 )
 
 func TestEnglish001(t *testing.T) {
-	files := []string{
-		"testdata/input-article.txt",
-		"testdata/input-te-wiki.txt",
+	bs, err := ioutil.ReadFile("testdata/input-article.txt")
+	if err != nil {
+		t.Fatalf("Input data file '%s' could not be read : %s", "testdata/input-article.txt", err.Error())
 	}
 
-	for _, fn := range files {
-		bs, err := ioutil.ReadFile(fn)
-		if err != nil {
-			t.Fatalf("Input data file '%s' could not be read : %s", fn, err.Error())
-		}
+	size := len(bs)
+	ti := NewTextTokenIterator(string(bs))
+	var toks []*TextToken
+	for err = ti.MoveNext(); err == nil; err = ti.MoveNext() {
+		toks = append(toks, ti.Item())
+	}
 
-		size := len(bs)
-		ti := NewTextTokenIterator(string(bs))
-		var toks []*TextToken
-		for err = ti.MoveNext(); err == nil; err = ti.MoveNext() {
-			toks = append(toks, ti.Item())
-		}
+	lt := toks[len(toks)-1]
+	if lt.End() != size-1 {
+		t.Errorf("Token offset drift by EOF.  Expected : %d, observed : %d", size, lt.End())
+	}
+}
 
-		lt := toks[len(toks)-1]
-		if lt.End() != size-1 {
-			t.Errorf("Token offset drift by EOF.  Expected : %d, observed : %d", size, lt.End())
-		}
+//
+
+func TestTelugu001(t *testing.T) {
+	bs, err := ioutil.ReadFile("testdata/input-te-wiki.txt")
+	if err != nil {
+		t.Fatalf("Input data file '%s' could not be read : %s", "testdata/input-te-wiki.txt", err.Error())
+	}
+
+	size := len(bs)
+	ti := NewTextTokenIterator(string(bs))
+	var toks []*TextToken
+	for err = ti.MoveNext(); err == nil; err = ti.MoveNext() {
+		toks = append(toks, ti.Item())
+	}
+
+	lt := toks[len(toks)-1]
+	if lt.End() != size-1 {
+		t.Errorf("Token offset drift by EOF.  Expected : %d, observed : %d", size, lt.End())
 	}
 }

--- a/tokenizer/types.go
+++ b/tokenizer/types.go
@@ -72,7 +72,7 @@ var TtDescriptions map[TokenType]string = map[TokenType]string{
 
 //
 
-func TypeOfRune(r rune) TokenType {
+func RuneType(r rune) TokenType {
 	switch {
 	case uni.IsSpace(r):
 		return TokSpace


### PR DESCRIPTION
- Make sentence assembly analogous to text tokenization
- Rename a few functions/methods for consistency
- Refactor and update tests
